### PR TITLE
refactor(dispatcher): use generic error placeholder for the ApiClient

### DIFF
--- a/src/transport/client/native.rs
+++ b/src/transport/client/native.rs
@@ -1,19 +1,36 @@
-use crate::transport::endpoints::{ConsensusTipRequest, SiaApiRequest};
+use crate::transport::endpoints::{ConsensusTipRequest, EndpointSchemaError, SiaApiRequest};
 use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine;
-use http::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use http::header::{HeaderMap, HeaderValue, InvalidHeaderValue, AUTHORIZATION};
 use reqwest::Client as ReqwestClient;
 use serde::Deserialize;
-use url::Url;
+use thiserror::Error;
+use url::{ParseError, Url};
 
-use crate::transport::client::{ApiClient, ApiClientError, ApiClientHelpers, Body as ClientBody, EndpointSchema};
+use crate::transport::client::{ApiClient, ApiClientHelpers, Body as ClientBody};
 use core::time::Duration;
 
 #[derive(Clone)]
 pub struct NativeClient {
     pub client: ReqwestClient,
     pub base_url: Url,
+}
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("Client initialization error: {0}")]
+    InitializationError(#[from] InvalidHeaderValue),
+    #[error("Reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("Url parse error: {0}")]
+    UrlParseError(#[from] ParseError),
+    #[error("Endpoint schema creation error: {0}")]
+    EndpointError(#[from] EndpointSchemaError),
+    #[error("Unexpected empty resposne, expected: {expected_type}")]
+    UnexpectedEmptyResponse { expected_type: String },
+    #[error("Unexpected HTTP status: [status: {status} body: {body}]")]
+    UnexpectedHttpStatus { status: http::StatusCode, body: String },
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -29,15 +46,16 @@ pub struct Conf {
 impl ApiClient for NativeClient {
     type Request = reqwest::Request;
     type Response = reqwest::Response;
+    type Error = ClientError;
     type Conf = Conf;
 
-    async fn new(conf: Self::Conf) -> Result<Self, ApiClientError> {
+    async fn new(conf: Self::Conf) -> Result<Self, Self::Error> {
         let mut headers = HeaderMap::new();
         if let Some(password) = &conf.password {
             let auth_value = format!("Basic {}", BASE64.encode(format!(":{}", password)));
             headers.insert(
                 AUTHORIZATION,
-                HeaderValue::from_str(&auth_value).map_err(|e| ApiClientError::BuildError(e.to_string()))?,
+                HeaderValue::from_str(&auth_value).map_err(ClientError::InitializationError)?,
             );
         }
         let timeout = conf.timeout.unwrap_or(10);
@@ -45,7 +63,7 @@ impl ApiClient for NativeClient {
             .default_headers(headers)
             .timeout(Duration::from_secs(timeout))
             .build()
-            .map_err(ApiClientError::ReqwestError)?;
+            .map_err(ClientError::ReqwestError)?;
 
         let ret = NativeClient {
             client,
@@ -56,43 +74,40 @@ impl ApiClient for NativeClient {
         Ok(ret)
     }
 
-    fn process_schema(&self, schema: EndpointSchema) -> Result<Self::Request, ApiClientError> {
-        let url = schema.build_url(&self.base_url)?;
+    fn to_data_request<R: SiaApiRequest>(&self, request: R) -> Result<Self::Request, Self::Error> {
+        let schema = request.to_endpoint_schema().map_err(ClientError::EndpointError)?;
+        let url = schema.build_url(&self.base_url).map_err(ClientError::UrlParseError)?;
         let req = match schema.body {
             ClientBody::None => self.client.request(schema.method.into(), url).build(),
             ClientBody::Utf8(body) => self.client.request(schema.method.into(), url).body(body).build(),
             ClientBody::Json(body) => self.client.request(schema.method.into(), url).json(&body).build(),
             ClientBody::Bytes(body) => self.client.request(schema.method.into(), url).body(body).build(),
         }
-        .map_err(ApiClientError::ReqwestError)?;
+        .map_err(ClientError::ReqwestError)?;
         Ok(req)
     }
 
-    async fn execute_request(&self, request: Self::Request) -> Result<Self::Response, ApiClientError> {
-        self.client.execute(request).await.map_err(ApiClientError::ReqwestError)
+    async fn execute_request(&self, request: Self::Request) -> Result<Self::Response, Self::Error> {
+        self.client.execute(request).await.map_err(ClientError::ReqwestError)
     }
 
-    async fn dispatcher<R: SiaApiRequest>(&self, request: R) -> Result<R::Response, ApiClientError> {
+    async fn dispatcher<R: SiaApiRequest>(&self, request: R) -> Result<R::Response, Self::Error> {
         let request = self.to_data_request(request)?;
 
         // Execute the request using reqwest client
-        let response = self
-            .client
-            .execute(request)
-            .await
-            .map_err(ApiClientError::ReqwestError)?;
+        let response = self.execute_request(request).await?;
 
         // Check the response status and return the appropriate result
         match response.status() {
             reqwest::StatusCode::OK => Ok(response
                 .json::<R::Response>()
                 .await
-                .map_err(ApiClientError::ReqwestError)?),
+                .map_err(ClientError::ReqwestError)?),
             reqwest::StatusCode::NO_CONTENT => {
                 if let Some(resp_type) = R::is_empty_response() {
                     Ok(resp_type)
                 } else {
-                    Err(ApiClientError::UnexpectedEmptyResponse {
+                    Err(ClientError::UnexpectedEmptyResponse {
                         expected_type: std::any::type_name::<R::Response>().to_string(),
                     })
                 }
@@ -106,7 +121,7 @@ impl ApiClient for NativeClient {
                     .map_err(|e| format!("Failed to retrieve body: {}", e))
                     .unwrap_or_else(|e| e);
 
-                Err(ApiClientError::UnexpectedHttpStatus { status, body })
+                Err(ClientError::UnexpectedHttpStatus { status, body })
             },
         }
     }


### PR DESCRIPTION
Used a `type Error` for the `ApiClient` that depends on the concrete impl.

note: avoided calling `request.to_endpoint_schema()?` in `to_data_request` so that the error from `to_endpoint_schema` isn't exposed in the trait `ApiClient` and not have to comply with `Self::Error` in non-concrete impls.