### PR TITLE
Refactor/client error handling and incorporate latest Sia consensus changes

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -53,10 +53,6 @@ pub trait Encodable {
     fn encode(&self, encoder: &mut Encoder);
 }
 
-impl Encodable for Hash256 {
-    fn encode(&self, encoder: &mut Encoder) { encoder.write_slice(&self.0); }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/tests/transaction.rs
+++ b/src/tests/transaction.rs
@@ -180,7 +180,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            let expected = Hash256::from_str("51832be911c7382502a2011cbddf1a9f689c4ca08c6a83ae3d021fb0dc781822").unwrap();
+            let expected = Hash256::from_str("92d9097978387a5da9d17435b796984dae6bd4342c88684d0949e406755c289c").unwrap();
             assert_eq!(hash, expected);
         }
 
@@ -194,11 +194,10 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            let expected = Hash256::from_str("1e612d1ee36338b93a36bac0c52007a2d678cde0bd9b95c36a1f61166cf02b87").unwrap();
+            let expected = Hash256::from_str("abac830016d15871dfefad87ddfce263a6936b77e8ec18e7712870d6bf771376").unwrap();
             assert_eq!(hash, expected);
         }
 
-        // Adding a signature to SatisfiedPolicy of PolicyHash should have no effect
         fn test_satisfied_policy_encode_hash_frivulous_signature() {
             let policy = SpendPolicy::Hash(Hash256::default());
 
@@ -213,7 +212,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            let expected = Hash256::from_str("80f3caa4507615945bc839c8505546decd91e9642120f26938b2fc370fa61992").unwrap();
+            let expected = Hash256::from_str("f6885827fb8a6d1a5751ce3f5a8580dc590f262f42e2dd9944052ec43ffc8d97").unwrap();
             assert_eq!(hash, expected);
         }
 
@@ -229,7 +228,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            let expected = Hash256::from_str("80f3caa4507615945bc839c8505546decd91e9642120f26938b2fc370fa61992").unwrap();
+            let expected = Hash256::from_str("e3bbd67ade36322f3de8458b1daa80fd21bb74af88c779b768908e007611f36e").unwrap();
             assert_eq!(hash, expected);
         }
 
@@ -253,7 +252,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            let expected = Hash256::from_str("c749f9ac53395ec557aed7e21d202f76a58e0de79222e5756b27077e9295931f").unwrap();
+            let expected = Hash256::from_str("0411ac20ae5472822bdc6c24c9ba2afdd828300ed3706cb1c07a8578276fd72d").unwrap();
             assert_eq!(hash, expected);
         }
 
@@ -289,7 +288,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            let expected = Hash256::from_str("13806b6c13a97478e476e0e5a0469c9d0ad8bf286bec0ada992e363e9fc60901").unwrap();
+            let expected = Hash256::from_str("b4d658dbc32b3e147d2736f75b14ca881d5c04963663993b6448c86f4f1a2815").unwrap();
             assert_eq!(hash, expected);
         }
 
@@ -308,8 +307,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            // FIXME update this in go equivalent. Preimage was changed from Vec<u8> to [u8; 32]
-            let expected = Hash256::from_str("2200a1464864cfaea8d312c1f16b5e00b816110896bea32ef7e1ccd43042d312").unwrap();
+            let expected = Hash256::from_str("5cd34ed67f2b2a55d016b4c485dfd1ca2eca75f6831cec9eed9494d6fa735315").unwrap();
             assert_eq!(hash, expected);
         }
 
@@ -338,8 +336,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            // FIXME update this in go equivalent. Preimage was changed from Vec<u8> to [u8; 32]
-            let expected = Hash256::from_str("08852e4ad99f726120028ecd82925b5f55fa441952cfc034a5cf4f09159b9372").unwrap();
+            let expected = Hash256::from_str("30abac67d0017556ae69416f54663edbe2fb14c7bcef028f2d228aef500e8f51").unwrap();
             assert_eq!(hash, expected);
         }
 
@@ -368,7 +365,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&satisfied_policy);
-            let expected = Hash256::from_str("8975e8cf990d5a20d9ec3dae18ed3b3a0c92edf967a8d93fcdef6a1eb73bb348").unwrap();
+            let expected = Hash256::from_str("69b26bdb1114af01e4626d2a31184706e1dc83d83063c9019f9ee66381bd6923").unwrap();
             assert_eq!(hash, expected);
         }
 
@@ -404,8 +401,7 @@ mod test {
             };
 
             let hash = Encoder::encode_and_hash(&vin);
-            // FIXME update this in go equivalent. Preimage was changed from Vec<u8> to [u8; 32]
-            let expected = Hash256::from_str("d31a05b155113a5244f14ae833887fd8b30f555129be126ca4b90592290db24a").unwrap();
+            let expected = Hash256::from_str("102a2924e7427ee3654bfeea8fc055fd82c2a403598484dbb704da9cdaada3ba").unwrap();
             assert_eq!(hash, expected);
         }
 

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -20,7 +20,7 @@ pub trait ApiClient: Clone {
     type Request;
     type Response;
     type Conf;
-    type Error;
+    type Error: std::error::Error + std::fmt::Debug;
 
     async fn new(conf: Self::Conf) -> Result<Self, Self::Error>
     where

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -28,8 +28,6 @@ pub trait ApiClient: Clone {
 
     fn process_schema(&self, schema: EndpointSchema) -> Result<Self::Request, Self::Error>;
 
-    fn to_data_request<R: SiaApiRequest>(&self, request: R) -> Result<Self::Request, Self::Error>;
-
     // TODO this can have a default implementation if an associated type can provide .execute()
     // eg self.client().execute(request).await.map_err(Self::ClientError)
     async fn execute_request(&self, request: Self::Request) -> Result<Self::Response, Self::Error>;

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -28,10 +28,6 @@ pub trait ApiClient: Clone {
 
     fn process_schema(&self, schema: EndpointSchema) -> Result<Self::Request, Self::Error>;
 
-    // TODO this can have a default implementation if an associated type can provide .execute()
-    // eg self.client().execute(request).await.map_err(Self::ClientError)
-    async fn execute_request(&self, request: Self::Request) -> Result<Self::Response, Self::Error>;
-
     // TODO default implementation should be possible if Execute::Response is a serde deserializable type
     async fn dispatcher<R: SiaApiRequest>(&self, request: R) -> Result<R::Response, Self::Error>;
 }

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -12,10 +12,6 @@ use url::Url;
 mod helpers;
 pub use helpers::ApiClientHelpers;
 
-// FIXME remove these client specific error types
-#[cfg(not(target_arch = "wasm32"))]
-use reqwest::Error as ReqwestError;
-
 #[cfg(target_arch = "wasm32")] use wasm::wasm_fetch::FetchError;
 
 // Client implementation is generalized

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -32,14 +32,6 @@ pub trait ApiClient: Clone {
     async fn dispatcher<R: SiaApiRequest>(&self, request: R) -> Result<R::Response, Self::Error>;
 }
 
-#[derive(Debug, Error)]
-pub enum DynamicTransportError {
-    #[error("DynamicTransportError::NoResponse: {0}")]
-    NoResponse(Box<dyn std::error::Error + Send + Sync>),
-    #[error("DynamicTransportError::UnexpectedResponse: {0}")]
-    UnexpectedResponse(Box<dyn std::error::Error + Send + Sync>),
-}
-
 // Not all client implementations will have an exact equivalent of HTTP methods
 // However, the client implementation should be able to map the HTTP methods to its own methods
 #[derive(Clone, Debug)]

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -9,7 +9,7 @@ use url::Url;
 #[cfg(not(target_arch = "wasm32"))] pub mod native;
 #[cfg(target_arch = "wasm32")] pub mod wasm;
 
-mod helpers;
+pub(crate) mod helpers;
 pub use helpers::ApiClientHelpers;
 
 // Client implementation is generalized

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -12,8 +12,6 @@ use url::Url;
 mod helpers;
 pub use helpers::ApiClientHelpers;
 
-#[cfg(target_arch = "wasm32")] use wasm::wasm_fetch::FetchError;
-
 // Client implementation is generalized
 // This allows for different client implementations (e.g., WebSocket, libp2p, etc.)
 // Any client implementation must implement the ApiClient trait and optionally ApiClientHelpers

--- a/src/transport/client/helpers.rs
+++ b/src/transport/client/helpers.rs
@@ -1,4 +1,4 @@
-use super::{ApiClient, ApiClientError};
+use super::ApiClient;
 use crate::transport::endpoints::{AddressBalanceRequest, AddressBalanceResponse, AddressesEventsRequest,
                                   ConsensusIndexRequest, ConsensusTipRequest, ConsensusTipstateRequest,
                                   ConsensusTipstateResponse, ConsensusUpdatesRequest, ConsensusUpdatesResponse,
@@ -10,39 +10,15 @@ use async_trait::async_trait;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum HelperError {
-    #[error("ApiClientHelpers::utxo_from_txid failed: {0}")]
-    UtxoFromTxid(#[from] UtxoFromTxidError),
-    #[error("ApiClientHelpers::get_transaction failed: {0}")]
-    GetTx(#[from] GetTransactionError),
-    #[error("ApiClientHelpers::get_unconfirmed_transaction: failed to fetch mempool {0}")]
-    GetUnconfirmedTx(#[from] ApiClientError),
-    #[error("ApiClientHelpers::select_unspent_outputs failed: {0}")]
-    SelectUtxos(#[from] SelectUtxosError),
-    #[error("ApiClientHelpers::get_event failed to fetch event: {0}")]
-    GetEvent(ApiClientError),
-    #[error("ApiClientHelpers::get_address_events failed: {0}")]
-    GetAddressEvents(ApiClientError),
-    #[error("ApiClientHelpers::broadcast_transaction failed to broadcast transaction: {0}")]
-    BroadcastTx(ApiClientError),
-    #[error("ApiClientHelpers::get_median_timestamp failed: {0}")]
-    GetMedianTimestamp(#[from] GetMedianTimestampError),
-    #[error("ApiClientHelpers::get_consensus_updates_since_height failed: {0}")]
-    UpdatesSinceHeight(#[from] UpdatesSinceHeightError),
-    #[error("ApiClientHelpers::find_where_utxo_spent failed: {0}")]
-    FindWhereUtxoSpent(#[from] FindWhereUtxoSpentError),
-}
-
-#[derive(Debug, Error)]
-pub enum UtxoFromTxidError {
+pub enum UtxoFromTxidError<ClientError> {
     #[error("ApiClientHelpers::utxo_from_txid: failed to fetch event {0}")]
-    FetchEvent(ApiClientError),
+    FetchEvent(#[from] ClientError),
     #[error("ApiClientHelpers::utxo_from_txid: invalid event variant {0:?}")]
     EventVariant(Event),
     #[error("ApiClientHelpers::utxo_from_txid: output index out of bounds txid: {txid} index: {index}")]
     OutputIndexOutOfBounds { txid: TransactionId, index: u32 },
     #[error("ApiClientHelpers::utxo_from_txid: get_unspent_outputs helper failed {0}")]
-    FetchUtxos(ApiClientError),
+    FetchUtxos(#[from] GetUnspentOutputsError<ClientError>),
     #[error("ApiClientHelpers::utxo_from_txid: output not found txid: {txid} index: {index}")]
     NotFound { txid: TransactionId, index: u32 },
     #[error("ApiClientHelpers::utxo_from_txid: found duplicate utxo txid: {txid} index: {index}")]
@@ -50,27 +26,57 @@ pub enum UtxoFromTxidError {
 }
 
 #[derive(Debug, Error)]
-pub enum GetTransactionError {
+pub enum GetTransactionError<ClientError> {
     #[error("ApiClientHelpers::get_transaction: failed to fetch event {0}")]
-    FetchEvent(#[from] ApiClientError),
+    FetchEvent(#[from] ClientError),
     #[error("ApiClientHelpers::get_transaction: unexpected variant error {0:?}")]
     EventVariant(EventDataWrapper),
 }
 
 #[derive(Debug, Error)]
-pub enum SelectUtxosError {
+pub enum GetUnconfirmedTransactionError<ClientError> {
+    #[error("ApiClientHelpers::get_unconfirmed_transaction: failed to fetch mempool {0}")]
+    FetchMempool(#[from] ClientError),
+}
+
+#[derive(Debug, Error)]
+pub enum FundTxSingleSourceError<ClientError> {
+    #[error("ApiClientHelpers::fund_tx_single_source: failed to select Utxos: {0}")]
+    SelectUtxos(#[from] SelectUtxosError<ClientError>),
+}
+
+#[derive(Debug, Error)]
+pub enum GetEventError<ClientError> {
+    #[error("ApiClientHelpers::get_event failed to fetch event: {0}")]
+    FetchEvent(#[from] ClientError),
+}
+
+#[derive(Debug, Error)]
+pub enum GetAddressEventsError<ClientError> {
+    #[error("ApiClientHelpers::get_address_events failed: {0}")]
+    FetchAddressEvents(#[from] ClientError),
+}
+
+#[derive(Debug, Error)]
+pub enum BroadcastTransactionError<ClientError> {
+    #[error("ApiClientHelpers::broadcast_transaction: broadcast failed: {0}")]
+    BroadcastTx(#[from] ClientError),
+}
+
+#[derive(Debug, Error)]
+pub enum SelectUtxosError<ClientError> {
     #[error(
         "ApiClientHelpers::select_unspent_outputs: insufficent funds, available: {available:?} required: {required:?}"
     )]
     Funding { available: Currency, required: Currency },
-    #[error("ApiClientHelpers::select_unspent_outputs: failed to fetch UTXOs {0}")]
-    FetchUtxos(#[from] ApiClientError),
+    #[error("ApiClientHelpers::select_unspent_outputs: failed to fetch UTXOs: {0}")]
+    GetUnspentOutputs(#[from] GetUnspentOutputsError<ClientError>),
 }
 
 #[derive(Debug, Error)]
-pub enum GetMedianTimestampError {
+pub enum GetMedianTimestampError<ClientError> {
     #[error("ApiClientHelpers::get_median_timestamp: failed to fetch consensus tipstate: {0}")]
-    FetchTipstate(#[from] ApiClientError),
+    FetchTipstate(#[from] ClientError),
     #[error(
         r#"ApiClientHelpers::get_median_timestamp: expected 11 timestamps in response: {0:?}.
            The walletd state is likely corrupt as it is evidently reporting a chain height of less
@@ -79,16 +85,22 @@ pub enum GetMedianTimestampError {
     TimestampVecLen(ConsensusTipstateResponse),
 }
 
-/// Helper methods for the ApiClient trait
-/// These generally provide higher level functionality than the base ApiClient trait
-/// This crate is focused on catering to the Komodo Defi Framework integration
+#[derive(Debug, Error)]
+pub enum GetUnspentOutputsError<ClientError> {
+    #[error("ApiClientHelpers::get_unspent_outputs: failed to fetch UTXOs {0}")]
+    FetchUtxos(#[from] ClientError),
+}
+
+/// ApiClientHelpers implements client agnostic helper methods catering to the Komodo Defi Framework
+/// integration. These methods provide higher level functionality than the base ApiClient trait.
+/// Clients can generally implement this as simply as `impl ApiClientHelpers for Client {}`.
 #[async_trait]
 pub trait ApiClientHelpers: ApiClient {
-    async fn current_height(&self) -> Result<u64, ApiClientError> {
+    async fn current_height(&self) -> Result<u64, Self::Error> {
         Ok(self.dispatcher(ConsensusTipRequest).await?.height)
     }
 
-    async fn address_balance(&self, address: Address) -> Result<AddressBalanceResponse, ApiClientError> {
+    async fn address_balance(&self, address: Address) -> Result<AddressBalanceResponse, Self::Error> {
         self.dispatcher(AddressBalanceRequest { address }).await
     }
 
@@ -97,13 +109,14 @@ pub trait ApiClientHelpers: ApiClient {
         address: &Address,
         limit: Option<i64>,
         offset: Option<i64>,
-    ) -> Result<Vec<SiacoinElement>, ApiClientError> {
-        self.dispatcher(GetAddressUtxosRequest {
-            address: address.clone(),
-            limit,
-            offset,
-        })
-        .await
+    ) -> Result<Vec<SiacoinElement>, GetUnspentOutputsError<Self::Error>> {
+        Ok(self
+            .dispatcher(GetAddressUtxosRequest {
+                address: address.clone(),
+                limit,
+                offset,
+            })
+            .await?)
     }
 
     /// Fetches unspent outputs for the given address and attempts to select a subset of outputs
@@ -124,11 +137,8 @@ pub trait ApiClientHelpers: ApiClient {
         &self,
         address: &Address,
         total_amount: Currency,
-    ) -> Result<(Vec<SiacoinElement>, Currency), HelperError> {
-        let mut unspent_outputs = self
-            .get_unspent_outputs(address, None, None)
-            .await
-            .map_err(SelectUtxosError::FetchUtxos)?;
+    ) -> Result<(Vec<SiacoinElement>, Currency), SelectUtxosError<Self::Error>> {
+        let mut unspent_outputs = self.get_unspent_outputs(address, None, None).await?;
 
         // Sort outputs from largest to smallest
         unspent_outputs.sort_by(|a, b| b.siacoin_output.value.0.cmp(&a.siacoin_output.value.0));
@@ -178,7 +188,7 @@ pub trait ApiClientHelpers: ApiClient {
         &self,
         tx_builder: &mut V2TransactionBuilder,
         public_key: &PublicKey,
-    ) -> Result<(), HelperError> {
+    ) -> Result<(), FundTxSingleSourceError<Self::Error>> {
         let address = public_key.address();
         let outputs_total: Currency = tx_builder.siacoin_outputs.iter().map(|output| output.value).sum();
 
@@ -191,7 +201,6 @@ pub trait ApiClientHelpers: ApiClient {
         for utxo in &selected_utxos {
             tx_builder.add_siacoin_input(utxo.clone(), SpendPolicy::PublicKey(public_key.clone()));
         }
-
         if change > Currency::DUST {
             // add change as an output
             tx_builder.add_siacoin_output((address, change).into());
@@ -203,36 +212,34 @@ pub trait ApiClientHelpers: ApiClient {
     /// Fetches a SiacoinElement(a UTXO) from a TransactionId and Index
     /// Walletd doesn't currently offer an easy way to fetch the SiacoinElement type needed to build
     /// SiacoinInputs.
-    async fn utxo_from_txid(&self, txid: &TransactionId, vout_index: u32) -> Result<SiacoinElement, HelperError> {
+    async fn utxo_from_txid(
+        &self,
+        txid: &TransactionId,
+        vout_index: u32,
+    ) -> Result<SiacoinElement, UtxoFromTxidError<Self::Error>> {
         let output_id = SiacoinOutputId::new(txid.clone(), vout_index);
 
         // fetch the Event via /api/events/{txid}
-        let event = self
-            .dispatcher(GetEventRequest { txid: txid.clone() })
-            .await
-            .map_err(UtxoFromTxidError::FetchEvent)?;
+        let event = self.dispatcher(GetEventRequest { txid: txid.clone() }).await?;
 
         // check that the fetched event is V2Transaction
         let tx = match event.data {
             EventDataWrapper::V2Transaction(tx) => tx,
-            _ => return Err(UtxoFromTxidError::EventVariant(event))?,
+            _ => return Err(UtxoFromTxidError::<Self::Error>::EventVariant(event)),
         };
 
         // check that the output index is within bounds
         if tx.siacoin_outputs.len() <= (vout_index as usize) {
-            return Err(UtxoFromTxidError::OutputIndexOutOfBounds {
+            return Err(UtxoFromTxidError::<Self::Error>::OutputIndexOutOfBounds {
                 txid: txid.clone(),
                 index: vout_index,
-            })?;
+            });
         }
 
         let output_address = tx.siacoin_outputs[vout_index as usize].address.clone();
 
         // fetch unspent outputs of the address
-        let address_utxos = self
-            .get_unspent_outputs(&output_address, None, None)
-            .await
-            .map_err(UtxoFromTxidError::FetchUtxos)?;
+        let address_utxos = self.get_unspent_outputs(&output_address, None, None).await?;
 
         // filter the utxos to find any matching the expected SiacoinOutputId
         let filtered_utxos: Vec<SiacoinElement> = address_utxos
@@ -243,54 +250,51 @@ pub trait ApiClientHelpers: ApiClient {
         // ensure only one utxo was found
         match filtered_utxos.len() {
             1 => Ok(filtered_utxos[0].clone()),
-            0 => Err(UtxoFromTxidError::NotFound {
+            0 => Err(UtxoFromTxidError::<Self::Error>::NotFound {
                 txid: txid.clone(),
                 index: vout_index,
-            })?,
-            _ => Err(UtxoFromTxidError::DuplicateUtxoFound {
+            }),
+            _ => Err(UtxoFromTxidError::<Self::Error>::DuplicateUtxoFound {
                 txid: txid.clone(),
                 index: vout_index,
-            })?,
+            }),
         }
     }
 
-    async fn get_event(&self, event_id: &Hash256) -> Result<Event, HelperError> {
-        self.dispatcher(GetEventRequest { txid: event_id.clone() })
-            .await
-            .map_err(HelperError::GetEvent)
+    async fn get_event(&self, event_id: &Hash256) -> Result<Event, GetEventError<Self::Error>> {
+        Ok(self.dispatcher(GetEventRequest { txid: event_id.clone() }).await?)
     }
 
-    async fn get_address_events(&self, address: Address) -> Result<Vec<Event>, HelperError> {
+    async fn get_address_events(&self, address: Address) -> Result<Vec<Event>, GetAddressEventsError<Self::Error>> {
         let request = AddressesEventsRequest {
             address,
             limit: None,
             offset: None,
         };
-        self.dispatcher(request).await.map_err(HelperError::GetAddressEvents)
+        Ok(self.dispatcher(request).await?)
     }
 
     /// Fetch a v2 transaction from the blockchain
     // FIXME Alright - this should return a Result<Option<V2Transaction>, HelperError> to allow for
     // logic to handle the case where the transaction is not found in the blockchain
     // ApiClientError must be refactored to allow this
-    async fn get_transaction(&self, txid: &TransactionId) -> Result<V2Transaction, HelperError> {
-        let event = self
-            .dispatcher(GetEventRequest { txid: txid.clone() })
-            .await
-            .map_err(GetTransactionError::FetchEvent)?;
+    async fn get_transaction(&self, txid: &TransactionId) -> Result<V2Transaction, GetTransactionError<Self::Error>> {
+        let event = self.dispatcher(GetEventRequest { txid: txid.clone() }).await?;
         match event.data {
             EventDataWrapper::V2Transaction(tx) => Ok(tx),
-            wrong_variant => Err(GetTransactionError::EventVariant(wrong_variant))?,
+            wrong_variant => Err(GetTransactionError::<Self::Error>::EventVariant(wrong_variant)),
         }
     }
 
     /// Fetch a v2 transaction from the transaction pool / mempool
     /// Returns Ok(None) if the transaction is not found in the mempool
-    async fn get_unconfirmed_transaction(&self, txid: &TransactionId) -> Result<Option<V2Transaction>, HelperError> {
+    async fn get_unconfirmed_transaction(
+        &self,
+        txid: &TransactionId,
+    ) -> Result<Option<V2Transaction>, GetUnconfirmedTransactionError<Self::Error>> {
         let found_in_mempool = self
             .dispatcher(TxpoolTransactionsRequest)
-            .await
-            .map_err(HelperError::GetUnconfirmedTx)?
+            .await?
             .v2transactions
             .into_iter()
             .find(|tx| tx.txid() == *txid);
@@ -299,41 +303,38 @@ pub trait ApiClientHelpers: ApiClient {
 
     /// Get the median timestamp of the chain's last 11 blocks
     /// This is used in the evaluation of SpendPolicy::After
-    async fn get_median_timestamp(&self) -> Result<u64, HelperError> {
-        let tipstate = self
-            .dispatcher(ConsensusTipstateRequest)
-            .await
-            .map_err(GetMedianTimestampError::FetchTipstate)?;
+    async fn get_median_timestamp(&self) -> Result<u64, GetMedianTimestampError<Self::Error>> {
+        let tipstate = self.dispatcher(ConsensusTipstateRequest).await?;
 
         // This can happen if the chain has less than 11 blocks
         // We assume the chain is at least 11 blocks long for this helper.
         if tipstate.prev_timestamps.len() != 11 {
-            return Err(GetMedianTimestampError::TimestampVecLen(tipstate))?;
+            return Err(GetMedianTimestampError::<Self::Error>::TimestampVecLen(tipstate));
         }
 
         let median_timestamp = tipstate.prev_timestamps[5];
         Ok(median_timestamp.timestamp() as u64)
     }
 
-    async fn broadcast_transaction(&self, tx: &V2Transaction) -> Result<(), HelperError> {
+    async fn broadcast_transaction(&self, tx: &V2Transaction) -> Result<(), BroadcastTransactionError<Self::Error>> {
         let request = TxpoolBroadcastRequest {
             transactions: vec![],
             v2transactions: vec![tx.clone()],
         };
 
-        self.dispatcher(request).await.map_err(HelperError::BroadcastTx)?;
+        self.dispatcher(request).await?;
         Ok(())
     }
 
-    async fn get_consensus_updates_since_height(
+    async fn get_consensus_updates(
         &self,
         begin_height: u64,
-    ) -> Result<ConsensusUpdatesResponse, HelperError> {
+    ) -> Result<ConsensusUpdatesResponse, GetConsensusUpdatesError<Self::Error>> {
         let index_request = ConsensusIndexRequest { height: begin_height };
         let chain_index = self
             .dispatcher(index_request)
             .await
-            .map_err(UpdatesSinceHeightError::FetchIndex)?;
+            .map_err(|e| GetConsensusUpdatesError::<Self::Error>::FetchIndex(e))?;
 
         let updates_request = ConsensusUpdatesRequest {
             height: chain_index.height,
@@ -343,8 +344,7 @@ pub trait ApiClientHelpers: ApiClient {
 
         self.dispatcher(updates_request)
             .await
-            .map_err(UpdatesSinceHeightError::FetchUpdates)
-            .map_err(HelperError::UpdatesSinceHeight)
+            .map_err(|e| GetConsensusUpdatesError::<Self::Error>::FetchUpdates(e))
     }
 
     /// Find the transaction that spent the given utxo
@@ -352,18 +352,12 @@ pub trait ApiClientHelpers: ApiClient {
     /// Returns Ok(None) if the utxo has not been spent
     async fn find_where_utxo_spent(
         &self,
-        siacoin_output_id: &SiacoinOutputId,
+        output_id: &SiacoinOutputId,
         begin_height: u64,
-    ) -> Result<Option<V2Transaction>, HelperError> {
-        // the SiacoinOutputId is displayed with h: prefix in the endpoint response so use we Hash256
-        let output_id = siacoin_output_id;
+    ) -> Result<Option<V2Transaction>, FindWhereUtxoSpentError<Self::Error>> {
+        let updates = self.get_consensus_updates(begin_height).await?;
 
-        let updates = self
-            .get_consensus_updates_since_height(begin_height)
-            .await
-            .map_err(|e| FindWhereUtxoSpentError::FetchUpdates(Box::new(e)))?;
-
-        // find the update that has the provided `siacoin_output_id`` in its "spent" field
+        // find the update that has the provided `output_id`` in its "spent" field
         let update_option = updates
             .applied
             .into_iter()
@@ -390,18 +384,18 @@ pub trait ApiClientHelpers: ApiClient {
 }
 
 #[derive(Debug, Error)]
-pub enum FindWhereUtxoSpentError {
+pub enum FindWhereUtxoSpentError<ClientError> {
     // Boxed to allow HelperError to be held within itself
     #[error("ApiClientHelpers::find_where_utxo_spent: failed to fetch consensus updates {0}")]
-    FetchUpdates(#[from] Box<HelperError>),
-    #[error("ApiClientHelpers::find_where_utxo_spent: scoid:{id} was not spent in the expected block")]
+    FetchUpdates(#[from] GetConsensusUpdatesError<ClientError>),
+    #[error("ApiClientHelpers::find_where_utxo_spent: SiacoinOutputId:{id} was not spent in the expected block")]
     SpendNotInBlock { id: SiacoinOutputId },
 }
 
 #[derive(Debug, Error)]
-pub enum UpdatesSinceHeightError {
+pub enum GetConsensusUpdatesError<ClientError> {
     #[error("ApiClientHelpers::get_consensus_updates_since_height: failed to fetch ChainIndex {0}")]
-    FetchIndex(ApiClientError),
+    FetchIndex(ClientError),
     #[error("ApiClientHelpers::get_consensus_updates_since_height: failed to fetch updates {0}")]
-    FetchUpdates(ApiClientError),
+    FetchUpdates(ClientError),
 }

--- a/src/transport/client/helpers.rs
+++ b/src/transport/client/helpers.rs
@@ -374,7 +374,11 @@ pub trait ApiClientHelpers: ApiClient {
         &self,
         tx: &V2Transaction,
     ) -> Result<(), BroadcastTransactionErrorGeneric<Self::Error>> {
+        // FIXME Alright this is not precise at all, waiting on clarification from Sia team
+        let basis = self.dispatcher(ConsensusTipRequest).await?;
+
         let request = TxpoolBroadcastRequest {
+            basis,
             transactions: vec![],
             v2transactions: vec![tx.clone()],
         };

--- a/src/transport/client/helpers.rs
+++ b/src/transport/client/helpers.rs
@@ -390,8 +390,11 @@ pub trait ApiClientHelpers: ApiClient {
         &self,
         tx: &V2Transaction,
     ) -> Result<(), BroadcastTransactionErrorGeneric<Self::Error>> {
-        // FIXME Alright this is not precise at all, waiting on clarification from Sia team
-        let basis = self.dispatcher(ConsensusTipRequest).await?;
+        // FIXME Alright possible this may fail if basis was not provided
+        let basis = match &tx.basis {
+            Some(basis) => basis.clone(),
+            None => self.dispatcher(ConsensusTipRequest).await?,
+        };
 
         let request = TxpoolBroadcastRequest {
             basis,

--- a/src/transport/client/native.rs
+++ b/src/transport/client/native.rs
@@ -29,8 +29,6 @@ pub enum NativeClientError {
     SchemaBuildUrl(#[from] EndpointSchemaError),
     #[error("NativeClient::process_schema: Failed to build request: {0}")]
     SchemaBuildRequest(reqwest::Error),
-    #[error("NativeClient::execute_request: Failed: {0}")]
-    ExecuteRequest(reqwest::Error),
     #[error("NativeClient::dispatcher: Failed to convert SiaApiRequest to reqwest::Request: {0}")]
     DispatcherBuildRequest(Box<NativeClientError>),
     #[error("NativeClient::dispatcher: Failed to execute reqwest::Request: {0}")]
@@ -100,13 +98,6 @@ impl ApiClient for NativeClient {
         }
         .map_err(NativeClientError::SchemaBuildRequest)?;
         Ok(req)
-    }
-
-    async fn execute_request(&self, request: Self::Request) -> Result<Self::Response, Self::Error> {
-        self.client
-            .execute(request)
-            .await
-            .map_err(NativeClientError::ExecuteRequest)
     }
 
     async fn dispatcher<R: SiaApiRequest>(&self, request: R) -> Result<R::Response, Self::Error> {

--- a/src/transport/client/native.rs
+++ b/src/transport/client/native.rs
@@ -102,10 +102,6 @@ impl ApiClient for NativeClient {
         Ok(req)
     }
 
-    fn to_data_request<R: SiaApiRequest>(&self, request: R) -> Result<Self::Request, Self::Error> {
-        self.process_schema(request.to_endpoint_schema()?)
-    }
-
     async fn execute_request(&self, request: Self::Request) -> Result<Self::Response, Self::Error> {
         self.client
             .execute(request)
@@ -115,7 +111,7 @@ impl ApiClient for NativeClient {
 
     async fn dispatcher<R: SiaApiRequest>(&self, request: R) -> Result<R::Response, Self::Error> {
         let request = self
-            .to_data_request(request)
+            .process_schema(request.to_endpoint_schema()?)
             .map_err(|e| NativeClientError::DispatcherBuildRequest(Box::new(e)))?;
 
         // Execute the request using reqwest client

--- a/src/transport/client/native.rs
+++ b/src/transport/client/native.rs
@@ -23,7 +23,7 @@ pub enum NativeClientError {
     BuildClient(reqwest::Error),
     #[error("NativeClient::new: Failed to ping server with ConsensusTipRequest: {0}")]
     PingServer(Box<NativeClientError>),
-    #[error("NativeClient::to_data_request: failed to convert request into schema: {0}")]
+    #[error("NativeClient::dispatcher: failed to convert request into schema: {0}")]
     RequestToSchema(#[from] SiaApiRequestError),
     #[error("NativeClient::process_schema: failed to build url: {0}")]
     SchemaBuildUrl(#[from] EndpointSchemaError),

--- a/src/transport/client/native.rs
+++ b/src/transport/client/native.rs
@@ -35,8 +35,8 @@ pub enum NativeClientError {
     DispatcherExecuteRequest(reqwest::Error),
     #[error("NativeClient::dispatcher: Failed to deserialize response body: {0}")]
     DispatcherDeserializeBody(reqwest::Error),
-    #[error("UnexpectedEmptyResponse error: {expected_type}")]
-    UnexpectedEmptyResponse { expected_type: String },
+    #[error("NativeClient::dispatcher: Expected:{expected_type} found 204 No Content")]
+    DispatcherUnexpectedEmptyResponse { expected_type: String },
     #[error("NativeClient::dispatcher: unexpected HTTP status:{status} body:{body}")]
     DispatcherUnexpectedStatus { status: http::StatusCode, body: String },
 }
@@ -124,7 +124,7 @@ impl ApiClient for NativeClient {
                 if let Some(resp_type) = R::is_empty_response() {
                     Ok(resp_type)
                 } else {
-                    Err(NativeClientError::UnexpectedEmptyResponse {
+                    Err(NativeClientError::DispatcherUnexpectedEmptyResponse {
                         expected_type: std::any::type_name::<R::Response>().to_string(),
                     })
                 }

--- a/src/transport/client/native.rs
+++ b/src/transport/client/native.rs
@@ -12,14 +12,8 @@ use crate::transport::client::{ApiClient, ApiClientHelpers, Body as ClientBody, 
 use core::time::Duration;
 
 pub mod error {
-    use crate::transport::client::helpers::{BroadcastTransactionErrorGeneric, CurrentHeightErrorGeneric,
-                                            FindWhereUtxoSpentErrorGeneric, FundTxSingleSourceErrorGeneric,
-                                            GetConsensusUpdatesErrorGeneric, GetMedianTimestampErrorGeneric,
-                                            GetTransactionErrorGeneric, GetUnconfirmedTransactionErrorGeneric,
-                                            GetUnspentOutputsErrorGeneric, SelectUtxosErrorGeneric,
-                                            UtxoFromTxidErrorGeneric};
-
     use super::*;
+    use crate::transport::client::helpers::generic_errors::*;
 
     pub type BroadcastTransactionError = BroadcastTransactionErrorGeneric<ClientError>;
     pub type UtxoFromTxidError = UtxoFromTxidErrorGeneric<ClientError>;

--- a/src/transport/client/wasm.rs
+++ b/src/transport/client/wasm.rs
@@ -145,7 +145,6 @@ impl ApiClient for WasmClient {
     }
 }
 
-// Implement the optional helper methods for ExampleClient
 // Just this is needed to implement the `ApiClientHelpers` trait
 // unless custom implementations for the traits methods are needed
 #[async_trait]

--- a/src/transport/client/wasm/wasm_fetch.rs
+++ b/src/transport/client/wasm/wasm_fetch.rs
@@ -60,7 +60,7 @@ impl FetchMethod {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Body {
     Utf8(String),
     Json(JsonValue),

--- a/src/transport/endpoints.rs
+++ b/src/transport/endpoints.rs
@@ -436,6 +436,7 @@ impl SiaApiRequest for GetAddressUtxosRequest {
 /// This type is ported from the Go codebase, representing the equivalent request-response pair in Rust.
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct TxpoolBroadcastRequest {
+    pub basis: ChainIndex,
     pub transactions: Vec<V1Transaction>,
     pub v2transactions: Vec<V2Transaction>,
 }

--- a/src/transport/endpoints.rs
+++ b/src/transport/endpoints.rs
@@ -364,11 +364,11 @@ pub type AddressesEventsResponse = Vec<Event>;
 /// - `offset`: An optional offset for paginated results. Corresponds to `int64` in Go.
 ///
 /// # Response
-/// - The response is a `Vec<SiacoinElement>` in Rust, corresponding to `[]types.SiacoinElement` in Go.
-///   - [Go Source for SiacoinElement Type](https://github.com/SiaFoundation/core/blob/300042fd2129381468356dcd87c5e9a6ad94c0ef/types/types.go#L614)
+/// - The response is a `GetAddressUtxosResponse` in Rust, corresponding to `SiacoinElementsResponse` in Go.
+///   - [Go Source for SiacoinElementsResponse Type](https://github.com/SiaFoundation/walletd/blob/94ac6b0543c7495752554ae543d4ad28b4a620a5/api/api.go#L177C1-L182C2)
 ///
 /// # References
-/// - [Go Source for the HTTP Endpoint](https://github.com/SiaFoundation/walletd/blob/6ff23fe34f6fa45a19bfb6e4bacc8a16d2c48144/api/server.go#L795)
+/// - [Go Source for the HTTP Endpoint](https://github.com/SiaFoundation/walletd/blob/94ac6b0543c7495752554ae543d4ad28b4a620a5/api/server.go#L1127)
 ///
 /// This type is ported from the Go codebase, representing the equivalent request-response pair in Rust.
 #[derive(Clone, Deserialize, Serialize, Debug)]
@@ -378,8 +378,17 @@ pub struct GetAddressUtxosRequest {
     pub offset: Option<i64>,
 }
 
+#[derive(Clone, Deserialize, Serialize, Debug)]
+/// equivalent of SiacoinElementsResponse in Go
+/// The ChainIndex is required to be provided while broadcasting any transaction that spends any of
+/// these UTXOs
+pub struct UtxosWithBasis {
+    pub basis: ChainIndex,
+    pub outputs: Vec<SiacoinElement>,
+}
+
 impl SiaApiRequest for GetAddressUtxosRequest {
-    type Response = Vec<SiacoinElement>;
+    type Response = UtxosWithBasis;
 
     fn to_endpoint_schema(&self) -> Result<EndpointSchema, SiaApiRequestError> {
         let mut path_params = HashMap::new();

--- a/src/types/hash.rs
+++ b/src/types/hash.rs
@@ -5,6 +5,13 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 use thiserror::Error;
 
+/*
+TODO:
+Hash256 once required custom serde and encoding due to handling various prefixes based on the context.
+These prefixes are now removed, so helpers like serde_as and derive_more could be used to reduce
+boilerplate.
+ */
+
 #[derive(Debug, Error)]
 pub enum Hash256Error {
     #[error("Hash256::from_str invalid hex: expected 32 byte hex string, found {0}")]
@@ -14,6 +21,8 @@ pub enum Hash256Error {
     #[error("Hash256::TryFrom<&[u8]> invalid slice length: expected 32 byte slice, found {0:?}")]
     InvalidSliceLength(Vec<u8>),
 }
+
+/// A 256 bit number representing a blake2b or sha256 hash in Sia's consensus protocol and APIs.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Hash256(pub [u8; 32]);
 

--- a/src/types/hash.rs
+++ b/src/types/hash.rs
@@ -1,3 +1,4 @@
+use crate::encoding::{Encodable, Encoder};
 use hex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;

--- a/src/types/hash.rs
+++ b/src/types/hash.rs
@@ -17,6 +17,10 @@ pub enum Hash256Error {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Hash256(pub [u8; 32]);
 
+impl Encodable for Hash256 {
+    fn encode(&self, encoder: &mut Encoder) { encoder.write_slice(&self.0); }
+}
+
 impl Serialize for Hash256 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -130,8 +130,15 @@ impl<'a> Encodable for CurrencyVersion<'a> {
 
 /// Preimage is a 32-byte array representing the preimage of a hash used in Sia's SpendPolicy::Hash
 /// Used to allow HLTC-style hashlock contracts in Sia
+// TODO - this type is now effectively identical to Hash256. It only exists because Preimage once
+// supported variable length preimages. Using Preimage(Hash256) would reduce code duplication, but
+// we should consider changing Hash256's name as Preimage does not represent a "hash".
 #[derive(Clone, Debug, Default, PartialEq, From, Into)]
 pub struct Preimage(pub [u8; 32]);
+
+impl Encodable for Preimage {
+    fn encode(&self, encoder: &mut Encoder) { encoder.write_slice(&self.0); }
+}
 
 impl Serialize for Preimage {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -182,7 +189,7 @@ impl<'de> Deserialize<'de> for Preimage {
 
 #[derive(Debug, Error)]
 pub enum PreimageError {
-    #[error("PreimageError: failed to convert from slice invalid length: {0}")]
+    #[error("Preimage:TryFrom<&[u8]>: invalid length, expected 32 bytes found: {0}")]
     InvalidSliceLength(usize),
 }
 
@@ -222,49 +229,8 @@ impl Encodable for Signature {
 impl Encodable for SatisfiedPolicy {
     fn encode(&self, encoder: &mut Encoder) {
         self.policy.encode(encoder);
-        let mut sigi: usize = 0;
-        let mut prei: usize = 0;
-
-        fn rec(policy: &SpendPolicy, encoder: &mut Encoder, sigi: &mut usize, prei: &mut usize, sp: &SatisfiedPolicy) {
-            match policy {
-                SpendPolicy::PublicKey(_) => {
-                    if *sigi < sp.signatures.len() {
-                        sp.signatures[*sigi].encode(encoder);
-                        *sigi += 1;
-                    } else {
-                        // Sia Go code panics here but our code assumes encoding will always be successful
-                        // TODO: check if Sia Go will fix this
-                        encoder.write_string("Broken PublicKey encoding, see SatisfiedPolicy::encode")
-                    }
-                },
-                SpendPolicy::Hash(_) => {
-                    if *prei < sp.preimages.len() {
-                        encoder.write_slice(&sp.preimages[*prei].0);
-                        *prei += 1;
-                    } else {
-                        // Sia Go code panics here but our code assumes encoding will always be successful
-                        // consider changing the signature of encode() to return a Result
-                        encoder.write_string("Broken Hash encoding, see SatisfiedPolicy::encode")
-                    }
-                },
-                SpendPolicy::Threshold { n: _, of } => {
-                    for p in of {
-                        rec(p, encoder, sigi, prei, sp);
-                    }
-                },
-                SpendPolicy::UnlockConditions(uc) => {
-                    for unlock_key in &uc.unlock_keys {
-                        if let UnlockKey::Ed25519(public_key) = unlock_key {
-                            rec(&SpendPolicy::PublicKey(public_key.clone()), encoder, sigi, prei, sp);
-                        }
-                        // else FIXME consider when this is possible, is it always developer error or could it be forced maliciously?
-                    }
-                },
-                _ => {},
-            }
-        }
-
-        rec(&self.policy, encoder, &mut sigi, &mut prei, self);
+        encoder.write_len_prefixed_vec(&self.signatures);
+        encoder.write_len_prefixed_vec(&self.preimages);
     }
 }
 

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -298,6 +298,13 @@ impl Encodable for SiacoinElement {
     }
 }
 
+/// A UTXO with its corresponding ChainIndex. This is not a type in Sia core, but is helpful because
+/// the ChainIndex is always needed when broadcasting a UTXO.
+pub struct UtxoWithBasis {
+    pub output: SiacoinElement,
+    pub basis: ChainIndex,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SiafundInputV2 {


### PR DESCRIPTION
Generalizes the error handling of ApiClient trait. The newly introduced WasmClientError and NativeClientError types follow the same pattern as Sia errors within KDF. They are purposefully verbose to allow each variant to represent a unique logical path.

Simplifies ApiClient trait by consolidating methods.

Incorporates changes to Sia consensus from:
https://github.com/SiaFoundation/core/pull/224
https://github.com/SiaFoundation/core/pull/220