### PR TITLE
Update README with link to official Sia Rust implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `sia-rust` is a Rust implementation of Siacoin to be used primarily by the [Komodo DeFi Framework](https://github.com/KomodoPlatform/komodo-defi-framework). This crate provides the core functionalities to create and sign Siacoin transactions. 
 
+See the [official rust implementation](https://github.com/SiaFoundation/sia-sdk-rs/) if you are building something new with Sia. This codebase was developed prior to the official implementation being fully mature. 
+
 ## Features
 
 - **V2 Transaction Builder**: Build Sia V2 transactions including SpendPolicy support


### PR DESCRIPTION
Adds a note to the README to point users to the official rust implementation. We really don't want new developers to use this codebase for any reason. 